### PR TITLE
test/e2e: refresh CR before updating it

### DIFF
--- a/test/e2e/issue24_test.go
+++ b/test/e2e/issue24_test.go
@@ -7,6 +7,7 @@ import (
 
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/KohlsTechnology/eunomia/pkg/apis"
 	gitopsv1alpha1 "github.com/KohlsTechnology/eunomia/pkg/apis/eunomia/v1alpha1"
@@ -85,6 +86,10 @@ func TestIssue24_RemovedResourceGetsDeleted(t *testing.T) {
 
 	// Step 2: change the CR to one with missing 'now-only' resource, then check that the pod gets deleted
 
+	err = framework.Global.Client.Get(context.TODO(), types.NamespacedName{namespace, gitops.ObjectMeta.Name}, gitops)
+	if err != nil {
+		t.Fatal(err)
+	}
 	gitops.Spec.TemplateSource.ContextDir = "test/e2e/testdata/issue24/template2"
 	err = framework.Global.Client.Update(context.Background(), gitops)
 	if err != nil {


### PR DESCRIPTION
In issue24_test.go, the PR #163 (adding Status to the CR) was failing
with the following error:

    time="2019-12-04T16:31:42+01:00" level=info msg="Started local operator"
    Found pod gcr.io/google-samples/hello-app:1.0 "hello-world-helm-76bc545546-zmp7v"
    Found pod gcr.io/google-samples/hello-app:1.0 "hello-world-helm-76bc545546-zmp7v"
    Found pod gcr.io/google-samples/hello-app:1.0 "hello-world-hierarchy-6b5cc6c69d-bvckb"
    Found pod gcr.io/google-samples/hello-app:1.0 "hello-world-issue24-fcc6c46f5-mmnnp"
    Found pod gcr.io/google-samples/hello-app:1.0 "hello-world-issue24-fcc6c46f5-mmnnp"
    Found pod gcr.io/google-samples/hello-app:2.0 "now-only-599f5bf5bd-9h64d"
    --- FAIL: TestIssue24_RemovedResourceGetsDeleted (25.20s)
        client.go:57: resource type GitOpsConfig with namespace/name (test-eunomia-operator/gitops-issue24) created
        util.go:97: Waiting for full availability of hello-world-issue24 pod
        util.go:97: Waiting for full availability of hello-world-issue24 pod
        util.go:97: Waiting for full availability of hello-world-issue24 pod
        util.go:114: pod hello-world-issue24 in namespace test-eunomia-operator is available
        util.go:114: pod now-only in namespace test-eunomia-operator is available
        issue24_test.go:91: Operation cannot be fulfilled on gitopsconfigs.eunomia.kohls.io "gitops-issue24": the object has been modified; please apply your changes to the latest version and try again

This commit fixes the error on my machine, by refreshing the
GitOpsConfig object before updating it in the cluster.

My understanging is, that the object in the test was getting stale,
because of the new Status field being added into it in the cluster
between the Create and Update calls.

